### PR TITLE
Support exit code

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,11 +14,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     ln -s /usr/bin/x86_64-linux-gnu-gcc /usr/local/bin/x86_64-unknown-linux-gnu-gcc
 
 # Install binsec
-COPY unisim.patch /opt/
-
-RUN git clone --depth 1 --branch 0.0.8 https://github.com/binsec/unisim_archisec /opt/unisim_archisec && \
-    (cd /opt/unisim_archisec && git apply /opt/unisim.patch && eval $(opam env) && dune build @install --release && dune install) && \
-    git clone --depth 1 --branch 0.9.1 https://github.com/binsec/binsec /opt/binsec && \
+RUN git clone --depth 1 --branch 0.0.10 https://github.com/binsec/unisim_archisec /opt/unisim_archisec && \
+    (cd /opt/unisim_archisec && eval $(opam env) && dune build @install --release && dune install) && \
+    git clone --depth 1 --branch 0.10.0 https://github.com/binsec/binsec /opt/binsec && \
     (cd /opt/binsec && eval $(opam env) && dune build @install --release && dune install)
 
 # Copy cargo-checkct to /src

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,10 @@ enum Command {
         /// Set a timeout in seconds. If not set, defaults to 10 minutes (600 seconds).
         #[arg(short, long, value_name = "SECONDS")]
         timeout: Option<u64>,
+
+        /// Do not raise an error if binsec cannot conclude on the tested implementation.
+        #[arg(long, action)]
+        skip_unknown: bool,
     },
     Add {
         /// Set the path to the checkct workspace,
@@ -68,7 +72,11 @@ fn main() -> Result<()> {
             let name = &name.unwrap_or("driver".to_owned());
             init_workspace(&dir, name)
         }
-        Command::Run { dir, timeout } => {
+        Command::Run {
+            dir,
+            timeout,
+            skip_unknown,
+        } => {
             let dir = dir.unwrap_or(std::env::current_dir()?).join("checkct");
             let timeout = timeout.unwrap_or(600);
             match run_binsec(&dir, Duration::from_secs(timeout))? {
@@ -82,7 +90,11 @@ fn main() -> Result<()> {
                 }
                 run::Status::Unknown => {
                     println!("UNKNOWN");
-                    Ok(())
+                    if skip_unknown {
+                        Ok(())
+                    } else {
+                        bail!("Unknown status!")
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::{path::PathBuf, time::Duration};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 
 mod add;
@@ -66,7 +66,7 @@ fn main() -> Result<()> {
         Command::Init { dir, name } => {
             let dir = dir.unwrap_or(std::env::current_dir()?);
             let name = &name.unwrap_or("driver".to_owned());
-            init_workspace(&dir, name)?;
+            init_workspace(&dir, name)
         }
         Command::Run { dir, timeout } => {
             let dir = dir.unwrap_or(std::env::current_dir()?).join("checkct");
@@ -74,20 +74,21 @@ fn main() -> Result<()> {
             match run_binsec(&dir, Duration::from_secs(timeout))? {
                 run::Status::Secure => {
                     println!("SECURE");
+                    Ok(())
                 }
                 run::Status::Insecure => {
                     println!("INSECURE");
+                    bail!("Insecure code!")
                 }
                 run::Status::Unknown => {
                     println!("UNKNOWN");
+                    Ok(())
                 }
             }
         }
         Command::Add { dir, name } => {
             let dir = dir.unwrap_or(std::env::current_dir()?);
-            add_driver(&dir, &name)?;
+            add_driver(&dir, &name)
         }
-    };
-
-    Ok(())
+    }
 }

--- a/tests/vulnerable_eq.rs
+++ b/tests/vulnerable_eq.rs
@@ -31,7 +31,7 @@ fn vulnerable() {
         .arg("--dir=tests/vulnerable_eq")
         .arg("--timeout=60")
         .assert()
-        .success();
+        .failure();
 
     let output = String::from_utf8_lossy(&output.get_output().stdout);
     println!("{output}");


### PR DESCRIPTION
:wave: 

This PR adds support of exit code that will be necessary when running `cargo-checkct` from CI and update the `Containerfile`.

Also, if binsec succeed the exit code will be set with these values:
- Secure => 0
- Insecure => 1
- Unknown => 0
Should we also return 1/error if we get "Unknown"?