### PR TITLE
Improve arm based mac linux cross compilation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,6 @@
 FROM docker.io/library/rust:slim-bullseye
 
 # Install dependencies and Rust toolchains
-# Create a symlink for "x86_64-unknown-linux-gnu-gcc" to fix using x86_64-unknown-linux-gnu toolchain.
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests git libgmp-dev gcc g++ opam pkgconf && \
@@ -10,8 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rustup target add riscv32imac-unknown-none-elf && \
     opam init --disable-sandboxing -y && \
     opam install -y dune dune-site menhir grain_dypgen ocamlgraph zarith toml bitwuzla && \
-    echo 'eval $(opam env)' >> /root/.bashrc && \
-    ln -s /usr/bin/x86_64-linux-gnu-gcc /usr/local/bin/x86_64-unknown-linux-gnu-gcc
+    echo 'eval $(opam env)' >> /root/.bashrc
 
 # Install binsec
 RUN git clone --depth 1 --branch 0.0.10 https://github.com/binsec/unisim_archisec /opt/unisim_archisec && \

--- a/examples/chachapoly/checkct/.cargo/config.toml
+++ b/examples/chachapoly/checkct/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["thumbv7em-none-eabihf", "riscv32imac-unknown-none-elf"]
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles"]
 
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]

--- a/examples/dalek/checkct/.cargo/config.toml
+++ b/examples/dalek/checkct/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["thumbv7em-none-eabihf", "riscv32imac-unknown-none-elf", "x86_64-unkno
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles"]
 
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]

--- a/examples/masked_aes/checkct/.cargo/config.toml
+++ b/examples/masked_aes/checkct/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["thumbv7em-none-eabihf"]
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles"]
 
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]

--- a/examples/memcmp/checkct/.cargo/config.toml
+++ b/examples/memcmp/checkct/.cargo/config.toml
@@ -4,8 +4,6 @@ target = ["thumbv7em-none-eabihf", "riscv32imac-unknown-none-elf"]
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles"]
 
-[target.x86_64-unknown-linux-gnu]
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]

--- a/examples/secp256K1/checkct/.cargo/config.toml
+++ b/examples/secp256K1/checkct/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["x86_64-unknown-linux-gnu"]
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles"]
 
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]

--- a/src/add.rs
+++ b/src/add.rs
@@ -14,7 +14,7 @@ pub fn add_driver(path: &Path, name: &str) -> Result<()> {
 
     // First recover the library name and the members of the checkct workspace
     let lib_name = get_lib_name(path)?;
-    println!("found library name: {}", lib_name);
+    println!("found library name: {lib_name}");
 
     let mut members = get_workspace_members(&workspace_dir)?;
     if members.contains(&name) {

--- a/src/init.rs
+++ b/src/init.rs
@@ -31,17 +31,10 @@ pub fn init_workspace(path: &Path, name: &str) -> Result<()> {
     // Create the config.toml file
     let mut config_file = fs::File::create(workspace_dir.join(".cargo").join("config.toml"))?;
     config_file.write_all(
-        format!(
-            include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/template/.cargo/config.toml"
-            )),
-            linker = if cfg!(on_apple_silicon) {
-                "linker = \"x86_64-unknown-linux-gnu-gcc\""
-            } else {
-                ""
-            }
-        )
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/template/.cargo/config.toml"
+        ))
         .as_bytes(),
     )?;
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -12,7 +12,7 @@ pub fn init_workspace(path: &Path, name: &str) -> Result<()> {
     // First of all, we need to check that the designated path is a proper cargo lib workspace,
     // and recover the name of the crate
     let lib_name = get_lib_name(path)?;
-    println!("found library name: {}", lib_name);
+    println!("found library name: {lib_name}");
 
     // The workspace directory name is hardcoded to /checkct
     let workspace_dir = path.join("checkct");

--- a/src/run.rs
+++ b/src/run.rs
@@ -235,10 +235,7 @@ pub fn run_binsec(dir: &Path, timeout: Duration) -> Result<Status> {
                             .to_string_lossy()
                     ));
 
-                println!(
-                    "{}",
-                    format!("  Running: {:?}", binsec_cmd).replace('\"', "")
-                );
+                println!("{}", format!("  Running: {binsec_cmd:?}").replace('\"', ""));
                 let output = binsec_cmd.output().context("Failed to run binsec")?;
 
                 let driver_status;

--- a/src/run.rs
+++ b/src/run.rs
@@ -78,11 +78,15 @@ pub fn run_binsec(dir: &Path, timeout: Duration) -> Result<Status> {
     std::env::set_current_dir(dir)
         .with_context(|| format!("Failed to set current directory to {dir:?}"))?;
     let cargo_path = which("cargo").context("Failed to find cargo")?;
-    let output = std::process::Command::new(cargo_path)
-        .arg("build")
-        .arg("--release")
-        .output()
-        .context("Failed to build drivers")?;
+    let mut cmd = std::process::Command::new(cargo_path);
+    cmd.arg("build").arg("--release");
+
+    // For ARM based MacOS, we need to change the linker for the x86 cross-compilation
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    cmd.arg("--config")
+        .arg("target.x86_64-unknown-linux-gnu.linker=\"x86_64-unknown-linux-gnu-gcc\"");
+
+    let output = cmd.output().context("Failed to build drivers")?;
 
     if !output.status.success() {
         bail!(

--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["thumbv7em-none-eabihf", "riscv32imac-unknown-none-elf", "x86_64-unkno
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles", "-C", "relocation-model=static"]
 
-[target.x86_64-unknown-linux-gnu]
-{linker}
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]


### PR DESCRIPTION
The goal of this PR is to improve the support of cross compilation.

Previously, the generated `config.toml` where different depending on the host the command was run on:
On MacOS ARM, the config contained for cross-compilation:
```
[target.x86_64-unknown-linux-gnu]
linker = "x86_64-unknown-linux-gnu-gcc"
```
This means that if the harness was generated on a mac, it would not be possible to run it from a linux except by playing with symlink.

Now, we set the linker directly in cargo build command depending on the OS cargo-checkct has been built for.