### PR TITLE
Enforce -fno-stack-protector when building the drivers

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -81,8 +81,7 @@ pub fn run_binsec(dir: &Path, timeout: Duration) -> Result<Status> {
     let mut cmd = std::process::Command::new(cargo_path);
     // Enforce -fno-stack-protector since we build with no_std
     cmd.env("CFLAGS", "-fno-stack-protector");
-    cmd.arg("build")
-        .arg("--release");
+    cmd.arg("build").arg("--release");
 
     // We need to change the linker for the x86 cross-compilation
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/src/run.rs
+++ b/src/run.rs
@@ -79,7 +79,10 @@ pub fn run_binsec(dir: &Path, timeout: Duration) -> Result<Status> {
         .with_context(|| format!("Failed to set current directory to {dir:?}"))?;
     let cargo_path = which("cargo").context("Failed to find cargo")?;
     let mut cmd = std::process::Command::new(cargo_path);
-    cmd.arg("build").arg("--release");
+    // Enforce -fno-stack-protector since we build with no_std
+    cmd.env("CFLAGS", "-fno-stack-protector");
+    cmd.arg("build")
+        .arg("--release");
 
     // We need to change the linker for the x86 cross-compilation
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/tests/subtle_eq/checkct/.cargo/config.toml
+++ b/tests/subtle_eq/checkct/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["thumbv7em-none-eabihf", "riscv32imac-unknown-none-elf", "x86_64-unkno
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles", "-C", "relocation-model=static"]
 
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]

--- a/tests/vulnerable_eq/checkct/.cargo/config.toml
+++ b/tests/vulnerable_eq/checkct/.cargo/config.toml
@@ -4,9 +4,6 @@ target = ["thumbv7em-none-eabihf", "riscv32imac-unknown-none-elf", "x86_64-unkno
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-nostartfiles", "-C", "relocation-model=static"]
 
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
 [unstable]
 unstable-options = true
 build-std = ["core", "panic_abort"]


### PR DESCRIPTION
This PR enforces the `-fno-stack-protector` that can be enabled by default in gcc in some linux distributions such as Ubuntu.